### PR TITLE
Adds Oxymonadida genera

### DIFF
--- a/curated_subtrees/Oxymonadida.tsv
+++ b/curated_subtrees/Oxymonadida.tsv
@@ -1,0 +1,22 @@
+taxon	taxon rank	candidate	taxon author	synonyms	alternative names	notes
+Eukaryota;Metamonada;Preaxostyla;Oxymonadida	order		Grassé 1952
+Eukaryota;Metamonada;Preaxostyla;Oxymonadida;Barroella	genus					no genetic data yet for this genus
+Eukaryota;Metamonada;Preaxostyla;Oxymonadida;Blattamonas	genus
+Eukaryota;Metamonada;Preaxostyla;Oxymonadida;Brachymonas	genus					no genetic data yet for this genus
+Eukaryota;Metamonada;Preaxostyla;Oxymonadida;Microrhopalodina	genus					no genetic data yet for this genus
+Eukaryota;Metamonada;Preaxostyla;Oxymonadida;Monocercomonoides	genus
+Eukaryota;Metamonada;Preaxostyla;Oxymonadida;Notila	genus					no genetic data yet for this genus
+Eukaryota;Metamonada;Preaxostyla;Oxymonadida;Opisthomitus	genus
+Eukaryota;Metamonada;Preaxostyla;Oxymonadida;Oxymonas	genus
+Eukaryota;Metamonada;Preaxostyla;Oxymonadida;Paranotila	genus					no genetic data yet for this genus
+Eukaryota;Metamonada;Preaxostyla;Oxymonadida;Polymastix	genus					no genetic data yet for this genus
+Eukaryota;Metamonada;Preaxostyla;Oxymonadida;Pyrsonymphidae
+Eukaryota;Metamonada;Preaxostyla;Oxymonadida;Pyrsonymphidae;Pyrsonympha	genus
+Eukaryota;Metamonada;Preaxostyla;Oxymonadida;Pyrsonymphidae;Dinenympha	genus
+Eukaryota;Metamonada;Preaxostyla;Oxymonadida;Saccinobaculus	genus
+Eukaryota;Metamonada;Preaxostyla;Oxymonadida;Sauromonas	genus					no genetic data yet for this genus
+Eukaryota;Metamonada;Preaxostyla;Oxymonadida;Streblomastix	genus
+Eukaryota;Metamonada;Preaxostyla;Oxymonadida;Tubulimonoides	genus					no genetic data yet for this genus
+Eukaryota;Metamonada;Preaxostyla;Paratrimastix	genus				Paratrimastigidae	single genus Paratrimastix in family Paratrimastigidae Zhang et al. 2015
+Eukaryota;Metamonada;Preaxostyla;Trimastigidae	family		Saville Kent 1880			only one described genus Trimastix in this group, but contains environmental lineages of unknown morphology
+Eukaryota;Metamonada;Preaxostyla;Trimastigidae;Trimastix	genus


### PR DESCRIPTION
This request adds genera of order Oxymonadida. It should be considered as template providing a starting point for further curation.